### PR TITLE
Add 'references' tag on the association

### DIFF
--- a/pages/gen/associations.md
+++ b/pages/gen/associations.md
@@ -58,14 +58,14 @@ type creditCard struct{
 
 ### Relate to table in database
 
-The association have to be speified by `gen.FieldRelate`
+The association have to be specified by `gen.FieldRelate`
 
 ```go
 card := g.GenerateModel("credit_cards")
 customer := g.GenerateModel("customers", gen.FieldRelate(field.HasMany, "CreditCards", card, 
     &field.RelateConfig{
         // RelateSlice: true,
-         GORMTag: field.GormTag{"foreignKey": []string{"CustomerRefer"}},
+         GORMTag: field.GormTag{"foreignKey": []string{"CustomerRefer"},"references": []string{"ID"}},
     }),
 )
 
@@ -81,7 +81,7 @@ type Customer struct {
     CreatedAt   time.Time      `gorm:"column:created_at;type:datetime(3)" json:"created_at"`
     UpdatedAt   time.Time      `gorm:"column:updated_at;type:datetime(3)" json:"updated_at"`
     DeletedAt   gorm.DeletedAt `gorm:"column:deleted_at;type:datetime(3)" json:"deleted_at"`
-    CreditCards []CreditCard   `gorm:"foreignKey:CustomerRefer" json:"credit_cards"`
+    CreditCards []CreditCard   `gorm:"foreignKey:CustomerRefer;references:ID" json:"credit_cards"`
 }
 
 
@@ -101,7 +101,7 @@ If associated model already exists, `gen.FieldRelateModel` can help you build as
 customer := g.GenerateModel("customers", gen.FieldRelateModel(field.HasMany, "CreditCards", model.CreditCard{}, 
     &field.RelateConfig{
         // RelateSlice: true,
-        GORMTag: field.GormTag{"foreignKey": []string{"CustomerRefer"}},
+        GORMTag: field.GormTag{"foreignKey": []string{"CustomerRefer"},"references": []string{"ID"}},
     }),
 )
 
@@ -158,7 +158,8 @@ u.WithContext(ctx).Omit(field.AssociationFields).Create(&user)
 // Skip all associations when creating a user
 ```
 
-Method `Field` will join a serious field name with ''.", for example: `u.BillingAddress.Field("Address1", "Street")` equals to `BillingAddress.Address1.Street`
+Method `Field` will join a serious field name with '', for example: `u.BillingAddress.Field("Address1", "Street")`
+equals to `BillingAddress.Address1.Street`
 
 ### Find Associations
 
@@ -203,7 +204,8 @@ u.Languages.Model(&user).Replace(&languageZH, &languageEN)
 
 ### Delete Associations
 
-Remove the relationship between source & arguments if exists, only delete the reference, won’t delete those objects from DB.
+Remove the relationship between source & arguments if exists, only delete the reference, won’t delete those objects from
+DB.
 
 ```go
 u := query.Use(db).User
@@ -231,7 +233,8 @@ u.Languages.Model(&user).Count()
 
 ### Delete with Select
 
-You are allowed to delete selected has one/has many/many2many relations with `Select` when deleting records, for example:
+You are allowed to delete selected has one/has many/many2many relations with `Select` when deleting records, for
+example:
 
 ```go
 u := query.Use(db).User
@@ -285,7 +288,8 @@ users, err := u.WithContext(ctx).Preload(u.Orders).Preload(u.Profile).Preload(u.
 
 ### Preload All
 
-`clause.Associations` can work with `Preload` similar like `Select` when creating/updating, you can use it to `Preload` all associations, for example:
+`clause.Associations` can work with `Preload` similar like `Select` when creating/updating, you can use it to `Preload`
+all associations, for example:
 
 ```go
 type User struct {
@@ -300,20 +304,22 @@ type User struct {
 users, err := u.WithContext(ctx).Preload(field.Associations).Find()
 ```
 
-`clause.Associations` won’t preload nested associations, but you can use it with [Nested Preloading](#nested-preloading) together, e.g:
+`clause.Associations` won’t preload nested associations, but you can use it with [Nested Preloading](#nested-preloading)
+together, e.g:
 
 ```go
 users, err := u.WithContext(ctx).Preload(u.Orders.OrderItems.Product).Find()
 ```
 
-To include soft deleted records in all associactions use relation scope `field.RelationFieldUnscoped`, e.g:
+To include soft deleted records in all associations use relation scope `field.RelationFieldUnscoped`, e.g:
+
 ```go
 users, err := u.WithContext(ctx).Preload(field.Associations.Scopes(field.RelationFieldUnscoped)).Find()
 ```
 
 ### Preload with select
 
-Specify selected columns with method `Select`. Foregin key must be selected.
+Specify selected columns with method `Select`. Foreign key must be selected.
 
 ```go
 type User struct {
@@ -382,4 +388,3 @@ db.Preload(u.Orders.OrderItems.Product).Preload(u.CreditCard).Find(&users)
 // And GEN won't preload unmatched order's OrderItems then
 db.Preload(u.Orders.On(o.State.Eq("paid"))).Preload(u.Orders.OrderItems).Find(&users)
 ```
-


### PR DESCRIPTION
- [] **ONLY** change English documents in the Pull Request, translations will be synced and translate them with https://translate.gorm.io/ or it will cause merge conflicts!

### What did this pull request do?

This PR adds 'references'  tag to the generated model. When you try to relate to table in database and the generated model doesn't have this tag, it will fail with 'GORM association error: invalid field for struct' error. Adding the tag fixes the error as now GORM is informed explicitly which field to relate to. 

Additionally the PR fixes some typos on the same page.